### PR TITLE
fix: Not use binary string in subprocess command

### DIFF
--- a/libtisbackup/common.py
+++ b/libtisbackup/common.py
@@ -785,7 +785,7 @@ class backup_generic(ABC):
                             self.logger.info('[%s] removing directory "%s"',self.backup_name,oldbackup_location)
                             if not self.dry_run:
                                 if self.type =="rsync+btrfs+ssh" or self.type == "rsync+btrfs":
-                                    cmd = "/bin/btrfs subvolume delete %s"%oldbackup_location.encode('ascii')
+                                    cmd = "/bin/btrfs subvolume delete %s"%oldbackup_location
                                     process = subprocess.Popen(cmd, shell=True,  stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True)
                                     log = monitor_stdout(process,'',self)
                                     returncode = process.returncode


### PR DESCRIPTION
Fix this issue: 
```
2023-03-08 17:44:56,800 ERROR cleanup_backup : Unable to remove directory/file "/mnt/data/server-srv/20220827-04h00m35". Error ('[server-srv] shell program exited with error code 1', "/bin/btrfs subvolume delete b'/mnt/data/server-srv/20220827-04h00m35'")
2023-03-08 17:44:56,801 INFO [server-srv] removing directory "/mnt/data/server-srv/20220828-04h00m35"
2023-03-08 17:44:56,806 ERROR [server-srv] shell program exited with error code: ERROR: Could not statfs: No such file or directory
```
