### PR TITLE
(fix): extract data from stats

### DIFF
--- a/libtisbackup/backup_rsync.py
+++ b/libtisbackup/backup_rsync.py
@@ -73,9 +73,11 @@ class backup_rsync(backup_generic):
                 else:
                     raise Exception('backup destination directory already exists : %s' % dest_dir)
 
-                options = ['-rt','--stats','--delete-excluded','--numeric-ids','--delete-after']
-                if self.logger.level:
-                    options.append('-P')
+                options = ['-rt','--stats','--delete-excluded','--numeric-ids','--delete-after', '--partial']
+                
+                if self.logger.level == logging.DEBUG:
+                    self.logger.warning(f"[{self.backup_name}] Note that stdout cannot be entire if it contains too much data and the server doesn't have enough RAM !")
+                    options.append('--progress')
 
                 if self.dry_run:
                     options.append('-d')

--- a/libtisbackup/backup_rsync_btrfs.py
+++ b/libtisbackup/backup_rsync_btrfs.py
@@ -80,11 +80,11 @@ class backup_rsync_btrfs(backup_generic):
                     else:
                         print(('btrfs subvolume create "%s"' %dest_dir))
 
+                options = ['-rt', '--stats', '--delete-excluded', '--numeric-ids', '--delete-after', '--partial']
 
-
-                options = ['-rt','--stats','--delete-excluded','--numeric-ids','--delete-after']
-                if self.logger.level:
-                    options.append('-P')
+                if self.logger.level == logging.DEBUG:
+                    self.logger.warning(f"[{self.backup_name}] Note that stdout cannot be entire if it contains too much data and the server doesn't have enough RAM !")
+                    options.append('--progress')
 
                 if self.dry_run:
                     options.append('-d')

--- a/libtisbackup/common.py
+++ b/libtisbackup/common.py
@@ -862,9 +862,11 @@ class backup_generic(ABC):
                 if not os.path.isdir(backup_dest):
                     os.makedirs(backup_dest)
 
-                options = ['-aP','--stats','--delete-excluded','--numeric-ids','--delete-after']
-                if self.logger.level:
-                    options.append('-P')
+                options = ['-a', '--stats', '--delete-excluded', '--numeric-ids', '--delete-after', '--partial']
+
+                if self.logger.level == logging.DEBUG:
+                    self.logger.warning(f"[{self.backup_name}] Note that stdout cannot be entire if it contains too much data and the server doesn't have enough RAM !")
+                    options.append('--progress')
 
                 if self.dry_run:
                     options.append('-d')

--- a/libtisbackup/common.py
+++ b/libtisbackup/common.py
@@ -889,7 +889,7 @@ class backup_generic(ABC):
 
                     for l in log.splitlines():
                         if l.startswith('Number of files:'):
-                            stats['total_files_count'] += int(re.findall('[0-9]+', l.split(':')[1])[0])
+                            stats['total_files_count'] += int(re.findall('[0-9]+', l.replace(',','').split(':')[1])[0])
                         if (l.startswith('Number of files transferred:') or 
                             l.startswith('Number of regular files transferred:')):
                             stats['written_files_count'] += int(l.replace(',','').split(':')[1])

--- a/libtisbackup/common.py
+++ b/libtisbackup/common.py
@@ -894,9 +894,9 @@ class backup_generic(ABC):
                             l.startswith('Number of regular files transferred:')):
                             stats['written_files_count'] += int(l.replace(',','').split(':')[1])
                         if l.startswith('Total file size:'):
-                            stats['total_bytes'] += float(l.replace(',','').split(':')[1].split()[0])
+                            stats['total_bytes'] += int(l.replace(',','').split(':')[1].split()[0])
                         if l.startswith('Total transferred file size:'):
-                            stats['written_bytes'] += float(l.replace(',','').split(':')[1].split()[0])
+                            stats['written_bytes'] += int(l.replace(',','').split(':')[1].split()[0])
                     returncode = process.returncode
                     ## deal with exit code 24 (file vanished)
                     if (returncode == 24):

--- a/libtisbackup/common.py
+++ b/libtisbackup/common.py
@@ -890,8 +890,9 @@ class backup_generic(ABC):
                     for l in log.splitlines():
                         if l.startswith('Number of files:'):
                             stats['total_files_count'] += int(re.findall('[0-9]+', l.split(':')[1])[0])
-                        if l.startswith('Number of files transferred:'):
-                            stats['written_files_count'] += int(l.split(':')[1])
+                        if (l.startswith('Number of files transferred:') or 
+                            l.startswith('Number of regular files transferred:')):
+                            stats['written_files_count'] += int(l.replace(',','').split(':')[1])
                         if l.startswith('Total file size:'):
                             stats['total_bytes'] += float(l.replace(',','').split(':')[1].split()[0])
                         if l.startswith('Total transferred file size:'):


### PR DESCRIPTION

- rsync 3.1.0 added the word "regular" into : "Number of files transferred"
- Number of files now contains comma
- total_bytes and written_bytes replace by an integer because it is stored as an integer in the database
- Remove --progress by default (Stdout cannot be entire if it contains too much data and the server doesn't have enough RAM, so at the end we don't have rsync stats)