### PR TITLE
(fix): SyntaxWarning with python 3.12

### DIFF
--- a/libtisbackup/backup_mysql.py
+++ b/libtisbackup/backup_mysql.py
@@ -152,7 +152,7 @@ class backup_mysql(backup_generic):
 
         filelist = os.listdir(self.backup_dir)
         filelist.sort()
-        p = re.compile('^\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}$')
+        p = re.compile(r'^\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}$')
         for item in filelist:
             if p.match(item):
                 dir_name = os.path.join(self.backup_dir,item)

--- a/libtisbackup/backup_oracle.py
+++ b/libtisbackup/backup_oracle.py
@@ -86,7 +86,7 @@ class backup_oracle(backup_generic):
 
                 file = open(localpath)
                 for line in file:
-                    if re.search('EXP-[0-9]+:', line) and not re.match('EXP-[0-9]+:', line).group(0).replace(':','') in self.ignore_error_oracle_code:
+                    if re.search(r'EXP-[0-9]+:', line) and not re.match(r'EXP-[0-9]+:', line).group(0).replace(':','') in self.ignore_error_oracle_code:
                         stats['status']='RMTemp'
                         self.clean_dumpfiles(dumpfile,dumplog)
                         raise Exception('Aborting, Not null exit code (%s) for "%s"' % (re.match('EXP-[0-9]+:', line).group(0).replace(':',''),cmd))

--- a/libtisbackup/backup_oracle.py
+++ b/libtisbackup/backup_oracle.py
@@ -131,7 +131,7 @@ class backup_oracle(backup_generic):
 
         filelist = os.listdir(self.backup_dir)
         filelist.sort()
-        p = re.compile('^\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}$') 
+        p = re.compile(r'^\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}$')
         for item in filelist:
             if p.match(item):
                 dir_name = os.path.join(self.backup_dir,item)

--- a/libtisbackup/backup_pgsql.py
+++ b/libtisbackup/backup_pgsql.py
@@ -138,7 +138,7 @@ class backup_pgsql(backup_generic):
 
         filelist = os.listdir(self.backup_dir)
         filelist.sort()
-        p = re.compile('^\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}$')
+        p = re.compile(r'^\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}$')
         for item in filelist:
             if p.match(item):
                 dir_name = os.path.join(self.backup_dir,item)

--- a/libtisbackup/backup_rsync.py
+++ b/libtisbackup/backup_rsync.py
@@ -128,8 +128,8 @@ class backup_rsync(backup_generic):
                 if (not self.rsync_module and not self.private_key):
                     raise Exception('If you don''t use SSH, you must specify a rsync module')
 
-                #rsync_re = re.compile('(?P<server>[^:]*)::(?P<export>[^/]*)/(?P<path>.*)')
-                #ssh_re = re.compile('((?P<user>.*)@)?(?P<server>[^:]*):(?P<path>/.*)')
+                #rsync_re = re.compile(r'(?P<server>[^:]*)::(?P<export>[^/]*)/(?P<path>.*)')
+                #ssh_re = re.compile(r'((?P<user>.*)@)?(?P<server>[^:]*):(?P<path>/.*)')
 
                 # Add ssh connection params
                 if self.rsync_module:
@@ -170,8 +170,8 @@ class backup_rsync(backup_generic):
 
                     log = monitor_stdout(process,ondata,self)
 
-                    reg_total_files = re.compile('Number of files: (?P<file>\d+)')
-                    reg_transferred_files = re.compile('Number of .*files transferred: (?P<file>\d+)')
+                    reg_total_files = re.compile(r'Number of files: (?P<file>\d+)')
+                    reg_transferred_files = re.compile(r'Number of .*files transferred: (?P<file>\d+)')
                     for l in log.splitlines():
                         line = l.replace(',','').replace('.','')
                         m = reg_total_files.match(line)
@@ -225,8 +225,8 @@ class backup_rsync(backup_generic):
         filelist.sort()
         filelist.reverse()
         full = ''
-        r_full = re.compile('^\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}$') 
-        r_partial = re.compile('^\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}.rsync$') 
+        r_full = re.compile(r'^\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}$')
+        r_partial = re.compile(r'^\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}.rsync$')
         # we take all latest partials younger than the latest full and the latest full
         for item in filelist:
             if r_partial.match(item) and item<current:
@@ -245,7 +245,7 @@ class backup_rsync(backup_generic):
 
         filelist = os.listdir(self.backup_dir)
         filelist.sort()
-        p = re.compile('^\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}$') 
+        p = re.compile(r'^\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}$')
         for item in filelist:
             if p.match(item):
                 dir_name = os.path.join(self.backup_dir,item)

--- a/libtisbackup/backup_rsync_btrfs.py
+++ b/libtisbackup/backup_rsync_btrfs.py
@@ -138,8 +138,8 @@ class backup_rsync_btrfs(backup_generic):
                 if (not self.rsync_module and not self.private_key):
                     raise Exception('If you don''t use SSH, you must specify a rsync module')
 
-                #rsync_re = re.compile('(?P<server>[^:]*)::(?P<export>[^/]*)/(?P<path>.*)')
-                #ssh_re = re.compile('((?P<user>.*)@)?(?P<server>[^:]*):(?P<path>/.*)')
+                #rsync_re = re.compile(r'(?P<server>[^:]*)::(?P<export>[^/]*)/(?P<path>.*)')
+                #ssh_re = re.compile(r'((?P<user>.*)@)?(?P<server>[^:]*):(?P<path>/.*)')
 
                 # Add ssh connection params
                 if self.rsync_module:
@@ -178,8 +178,8 @@ class backup_rsync_btrfs(backup_generic):
 
                     log = monitor_stdout(process,ondata,self)
 
-                    reg_total_files = re.compile('Number of files: (?P<file>\d+)')
-                    reg_transferred_files = re.compile('Number of .*files transferred: (?P<file>\d+)')
+                    reg_total_files = re.compile(r'Number of files: (?P<file>\d+)')
+                    reg_transferred_files = re.compile(r'Number of .*files transferred: (?P<file>\d+)')
                     for l in log.splitlines():
                         line = l.replace(',','').replace('.','')
                         m = reg_total_files.match(line)
@@ -244,8 +244,8 @@ class backup_rsync_btrfs(backup_generic):
         filelist.sort()
         filelist.reverse()
         full = ''
-        r_full = re.compile('^\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}$') 
-        r_partial = re.compile('^\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}.rsync$') 
+        r_full = re.compile(r'^\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}$')
+        r_partial = re.compile(r'^\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}.rsync$')
         # we take all latest partials younger than the latest full and the latest full
         for item in filelist:
             if r_partial.match(item) and item<current:
@@ -263,7 +263,7 @@ class backup_rsync_btrfs(backup_generic):
 
         filelist = os.listdir(self.backup_dir)
         filelist.sort()
-        p = re.compile('^\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}$') 
+        p = re.compile(r'^\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}$')
         for item in filelist:
             if p.match(item):
                 dir_name = os.path.join(self.backup_dir,item)

--- a/libtisbackup/backup_samba4.py
+++ b/libtisbackup/backup_samba4.py
@@ -139,7 +139,7 @@ class backup_samba4(backup_generic):
 
         filelist = os.listdir(self.backup_dir)
         filelist.sort()
-        p = re.compile('^\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}$')
+        p = re.compile(r'^\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}$')
         for item in filelist:
             if p.match(item):
                 dir_name = os.path.join(self.backup_dir,item)

--- a/libtisbackup/backup_sqlserver.py
+++ b/libtisbackup/backup_sqlserver.py
@@ -139,7 +139,7 @@ class backup_sqlserver(backup_generic):
 
         filelist = os.listdir(self.backup_dir)
         filelist.sort()
-        p = re.compile('^%s-(?P<date>\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}).bak.gz$' % self.db_name)
+        p = re.compile(r'^%s-(?P<date>\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}).bak.gz$' % self.db_name)
         for item in filelist:
             sr = p.match(item)
             if sr:

--- a/libtisbackup/backup_switch.py
+++ b/libtisbackup/backup_switch.py
@@ -199,7 +199,7 @@ class backup_switch(backup_generic):
         child.expect('#--')
         child.expect("#")
         child.close()
-        myre = re.compile("#--+")
+        myre = re.compile(r"#--+")
         config = myre.split(open(filename).read())[2]
         with open(filename,'w') as f:
             f.write(config)

--- a/libtisbackup/backup_xcp_metadata.py
+++ b/libtisbackup/backup_xcp_metadata.py
@@ -72,7 +72,7 @@ class backup_xcp_metadata(backup_generic):
 
         filelist = os.listdir(self.backup_dir)
         filelist.sort()
-        p = re.compile('^%s-(?P<date>\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}).dump.gz$' % self.server_name) 
+        p = re.compile(r'^%s-(?P<date>\d{8,8}-\d{2,2}h\d{2,2}m\d{2,2}).dump.gz$' % self.server_name)
         for item in filelist:
             sr = p.match(item)
             if sr:

--- a/libtisbackup/backup_xva.py
+++ b/libtisbackup/backup_xva.py
@@ -60,7 +60,7 @@ class backup_xva(backup_generic):
         tar = tarfile.open(filename)
         members = tar.getmembers()
         for tarinfo in members:
-            if re.search('^[0-9]*$',os.path.basename(tarinfo.name)):
+            if re.search(r'^[0-9]*$',os.path.basename(tarinfo.name)):
                 sha1sum = hashlib.sha1(tar.extractfile(tarinfo).read()).hexdigest()
                 sha1sum2 = tar.extractfile(tarinfo.name+'.checksum').read()
                 if not sha1sum == sha1sum2:

--- a/libtisbackup/common.py
+++ b/libtisbackup/common.py
@@ -526,7 +526,7 @@ class backup_generic(ABC):
     ssh_port=22
 
     def __init__(self,backup_name, backup_dir,dbstat=None,dry_run=False):
-        if not re.match('^[A-Za-z0-9_\-\.]*$',backup_name):
+        if not re.match(r'^[A-Za-z0-9_\-\.]*$',backup_name):
             raise Exception('The backup name %s should contain only alphanumerical characters' % backup_name)
         self.backup_name = backup_name
         self.backup_dir = backup_dir
@@ -889,7 +889,7 @@ class backup_generic(ABC):
 
                     for l in log.splitlines():
                         if l.startswith('Number of files:'):
-                            stats['total_files_count'] += int(re.findall('[0-9]+', l.split(':')[1])[0])
+                            stats['total_files_count'] += int(re.findall(r'[0-9]+', l.split(':')[1])[0])
                         if l.startswith('Number of files transferred:'):
                             stats['written_files_count'] += int(l.split(':')[1])
                         if l.startswith('Total file size:'):

--- a/libtisbackup/iniparse/ini.py
+++ b/libtisbackup/iniparse/ini.py
@@ -357,7 +357,7 @@ class INISection(config.ConfigNamespace):
             else:
                 raise
         if del_empty:
-            value = re.sub('\n+', '\n', value)
+            value = re.sub(r'\n+', r'\n', value)
         return value
 
     def _getitem(self, key):

--- a/tisbackup_gui.py
+++ b/tisbackup_gui.py
@@ -286,7 +286,7 @@ def check_usb_disk():
     usb_disk_list = []
     for name in glob.glob('/dev/sd[a-z]'):
         for line in os.popen("udevadm info -q env -n %s" % name):
-            if re.match("ID_PATH=.*usb.*", line):
+            if re.match(r"ID_PATH=.*usb.*", line):
                 usb_disk_list += [ name ]
 
     if len(usb_disk_list) == 0:


### PR DESCRIPTION
Change all Regex to raw format to fix the SyntaxWarning

[Changelog of python](https://docs.python.org/3/whatsnew/3.12.html#other-language-changes) :
- Invalid backslash escape sequences in strings now warn with SyntaxWarning instead of DeprecationWarning, making them more visible. (They will become syntax errors in the future.)